### PR TITLE
Remove wrong implementation of MaxSubArraySum

### DIFF
--- a/exercises/MaxSubArraySum/Complete/MaxSubArraySumComplete.php
+++ b/exercises/MaxSubArraySum/Complete/MaxSubArraySumComplete.php
@@ -32,28 +32,4 @@ final class MaxSubArraySumComplete
 
         return $max;
     }
-
-    /** @param int[] $input */
-    public static function max2(array $input, int $n): int
-    {
-        $length = count($input);
-        if ($length < $n) {
-            return 0;
-        }
-        $maxSum = 0;
-        $tempSum = 0;
-
-        for ($i = 0; $i < $n; ++$i) {
-            $maxSum += $input[$i];
-        }
-
-        $tempSum = $maxSum;
-
-        for ($i = $n; $i < $length; ++$i) {
-            $tempSum = ($tempSum - $input[$i - $n] + $input[$i]);
-            $maxSum = max($maxSum, $tempSum);
-        }
-
-        return $maxSum;
-    }
 }

--- a/exercises/MaxSubArraySum/MaxSubArraySum.php
+++ b/exercises/MaxSubArraySum/MaxSubArraySum.php
@@ -9,7 +9,7 @@ namespace Exercises\MaxSubArraySum;
  *
  * @method static int max(int[] $input, int $n)
  * @example MaxSubArraySum::max([1, 2, 3], 2)) === 5
- * @example MaxSubArraySum::max([2, 6, 9, 2, 1, 8, 5, 6, 3], 3)) === 19
+ * @example MaxSubArraySum::max([2, 6, 9, 2, 1, 8, 5, 6, 3], 3)) === 23
  */
 final class MaxSubArraySum
 {

--- a/tests/MaxSubArraySum/Complete/MaxSubArrayCompleteTest.php
+++ b/tests/MaxSubArraySum/Complete/MaxSubArrayCompleteTest.php
@@ -16,10 +16,6 @@ final class MaxSubArrayCompleteTest extends TestCase
             method_exists(MaxSubArraySumComplete::class, 'max1'),
             'Class does not have static method max1'
         );
-        self::assertTrue(
-            method_exists(MaxSubArraySumComplete::class, 'max2'),
-            'Class does not have static method max2'
-        );
     }
 
     public function testMax1(): void
@@ -28,16 +24,6 @@ final class MaxSubArrayCompleteTest extends TestCase
         self::assertSame(
             19,
             MaxSubArraySumComplete::max1([2, 6, 9, 2, 1, 8, 5, 6, 3], 3)
-        );
-        self::assertSame(0, MaxSubArraySumComplete::max1([1, 2, 3], 5));
-    }
-
-    public function testMax2(): void
-    {
-        self::assertSame(5, MaxSubArraySumComplete::max2([1, 2, 3], 2));
-        self::assertSame(
-            19,
-            MaxSubArraySumComplete::max2([2, 6, 9, 2, 1, 8, 5, 6, 3], 3)
         );
         self::assertSame(0, MaxSubArraySumComplete::max1([1, 2, 3], 5));
     }


### PR DESCRIPTION
As pointed out in https://github.com/azdanov/php-interview-exercises/issues/47, this exercise includes a wrong example.
I fixed the value for that and removed one of the provided implementations of the exercise as it doesn't pass the tests with the right value.